### PR TITLE
feat: Add overwrite flag to allow multiple runs in a single workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This action reads all variable defined in a file and makes them available as env
 
 ### In the workflow.yml
 
-1.  Use the checked out action in your worflow:
+1.  Use the checked out action in your workflow:
 
         - name: Set staging env vars
           uses: university-of-york/ds-devtool-setEnvVars@v1
@@ -19,7 +19,7 @@ This action reads all variable defined in a file and makes them available as env
 
 ### Using secrets with this action
 
-Any secrets defined as environment variables when using action are setup as environment varaibles to the steps in the workflow. This does not reveal the value of the secret. An example of using secrets is as follows:
+Any secrets defined as environment variables when using action are setup as environment variables to the steps in the workflow. This does not reveal the value of the secret. An example of using secrets is as follows:
 
         - name: Set staging env vars
           uses: university-of-york/ds-devtool-setEnvVars@v1
@@ -29,3 +29,16 @@ Any secrets defined as environment variables when using action are setup as envi
               MY_SECRET: ${{secrets.MY_SECRET}}
 
 The secret can then be used in the workflow steps as `$MY_SECRET`.
+
+### Overwriting existing variables
+
+By default, this action will not replace environment variables that have been previously defined. You may change
+this by setting the `overwrite` flag:
+
+        - name: Set staging env vars
+          uses: university-of-york/ds-devtool-setEnvVars@v1
+          with:
+            envFile: 'staging.env'
+            overwrite: true
+          env:
+              MY_SECRET: ${{secrets.MY_SECRET}}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const core = require('@actions/core');
+const dotenv = require('dotenv');
 
 const envFile = core.getInput('envFile', { required: true });
 
@@ -9,7 +10,18 @@ if (!fs.existsSync(`${envFile}`)) {
     core.error(`${envFile} does not exist`);
 }
 
-require('dotenv').config({ path: path.join(process.cwd(), `${envFile}`) });
+const envFilePath = path.join(process.cwd(), `${envFile}`);
+const overwrite = core.getBooleanInput('overwrite');
+
+if (overwrite) {
+    const envConfig = dotenv.parse(fs.readFileSync(envFilePath));
+
+    for (const key of envConfig) {
+        process.env[key] = envConfig[key];
+    }
+} else {
+    dotenv.config({ path: envFilePath });
+}
 
 try {
     // get env vars passed into this actions and add them to the repo env


### PR DESCRIPTION
Hello! 👋 

We have a use case in https://github.com/university-of-york/esg-api-people-projection to deploy multiple environments on merge. However, running this action multiple times per workflow does not behave as expected due to https://github.com/motdotla/dotenv#what-happens-to-environment-variables-that-were-already-set. Due to this, I propose a flag whereby you can opt in to overwriting existing environment variables with this action. 🙂 

I'm not sure how this action is released so if I need to do anything else in this PR to facilitate that, please let me know. 👍 

Thanks!