### PR TITLE
chore(docs): Add notice explaining repository visibility to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,9 @@ npm run move-major-tag
 ```
 
 [configuration variables]: https://docs.github.com/en/actions/learn-github-actions/variables#using-the-vars-context-to-access-configuration-variable-values
+
+## Repository visibility
+
+This repository is intentionally public to allow this action to be published on the GitHub marketplace.
+
+However, we are now recommending that GitHub's configuration variables should be used instead of this action, so this action may be made private or retired altogether within the next year.


### PR DESCRIPTION
## Related Links

[University of York information on revision control](https://www.york.ac.uk/it-services/tools/revision-control/), containing the university's policy on public repositories.

## What

Added text to the readme explaining why this repository is public, and that this may change in the future because we are now recommending other ways to work with environment variables in Github Actions.

## Why

This change was made in response to a change in university policy requiring public repositories to state the reason for public visibility. 
